### PR TITLE
VWAP indicator added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
+.noseids
 
 # Translations
 *.mo

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# IDE/Editor
+.vscode/

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ For the full history of changes see [CHANGELOG](https://github.com/nardew/talipp
 - True Strength Index (TSI)
 - Ultimate Oscillator (UO)
 - Vortex Indicator (VTX)
+- Volume Weighted Average Price (VWAP)
 
 ### Installation
 ```bash

--- a/examples/indicators.py
+++ b/examples/indicators.py
@@ -3,7 +3,7 @@ import random
 from talipp.ohlcv import OHLCVFactory
 from talipp.indicators import AccuDist, ADX, ALMA, AO, Aroon, ATR, BB, BOP, CCI, ChaikinOsc, ChandeKrollStop, CHOP, CoppockCurve, DEMA, DonchianChannels, DPO, EMA, EMV, ForceIndex, HMA, \
     Ichimoku, KAMA, KeltnerChannels, KST, KVO, MACD, MassIndex, MeanDev, OBV, PivotsHL, ROC, RSI, ParabolicSAR, SFX, SMA, SMMA, SOBV, \
-    StdDev, Stoch, StochRSI, TEMA, TRIX, TSI, UO, VTX, VWMA, WMA
+    StdDev, Stoch, StochRSI, TEMA, TRIX, TSI, UO, VTX, VWAP, VWMA, WMA
 
 
 if __name__ == "__main__":
@@ -63,5 +63,6 @@ if __name__ == "__main__":
     print(f'TSI: {TSI(13, 25, close)[-1]}')
     print(f'UO: {UO(7, 14, 28, ohlcv)[-1]}')
     print(f'VTX: {VTX(14, ohlcv)[-1]}')
+    print(f'VWAP: {VWAP(ohlcv)[-1]}')
     print(f'VWMA: {VWMA(20, ohlcv)[-1]}')
     print(f'WMA: {WMA(9, close)[-1]}')

--- a/talipp/indicators/VWAP.py
+++ b/talipp/indicators/VWAP.py
@@ -58,3 +58,37 @@ class VWAP(Indicator):
 
         for listener in self.output_listeners:
             listener.remove_input_value()
+
+    def reset(self):
+        while (True):
+            if len(self.input_values) > 0:
+                value = self.input_values[-1]
+                self.cumsumPV -= value.volume*(
+                    value.high+value.low+value.close)/3
+                self.cumsumV -= value.volume
+                self.input_values.pop(-1)
+
+                for sub_indicator in self.sub_indicators:
+                    sub_indicator.remove_input_value()
+
+                for lst in self.managed_sequences:
+                    if isinstance(lst, Indicator):
+                        lst.remove_input_value()
+                    else:
+                        if len(lst) > 0:
+                            lst.pop(-1)
+
+                for listener in self.output_listeners:
+                    listener.remove_input_value()
+            else:
+                self.cumsumPV = 0
+                self.cumsumV = 0
+                break
+
+        while (True):
+            if len(self.output_values) > 0:
+                self.output_values.pop(-1)
+
+                self._remove_output_value()
+            else:
+                break

--- a/talipp/indicators/VWAP.py
+++ b/talipp/indicators/VWAP.py
@@ -1,0 +1,60 @@
+# =============================================================================
+# Created By  : Pramit Biswas
+# Created Date: Sun Jun 06 19:55:00 IST 2021
+# =============================================================================
+
+from typing import List, Any
+
+from talipp.indicators.Indicator import Indicator
+from talipp.ohlcv import OHLCV
+
+
+class VWAP(Indicator):
+    """
+    Volume Weighted Average Price
+    Output: a list of floats
+    ALERT: This does not check season starting.
+    """
+
+    def __init__(self, input_values: List[OHLCV] = None):
+        super().__init__()
+
+        self.cumsumPV = 0
+        self.cumsumV = 0
+
+        self.initialize(input_values)
+
+    def _calculate_new_value(self) -> Any:
+        value = self.input_values[-1]
+
+        self.cumsumPV += value.volume*(value.high+value.low+value.close)/3
+        self.cumsumV += value.volume
+
+        if (self.cumsumV != 0):
+            return self.cumsumPV/self.cumsumV
+        else:
+            return None
+
+    def remove_input_value(self) -> None:
+        for sub_indicator in self.sub_indicators:
+            sub_indicator.remove_input_value()
+
+        if len(self.input_values) > 0:
+            value = self.input_values[-1]
+            self.cumsumPV -= value.volume*(value.high+value.low+value.close)/3
+            self.cumsumV -= value.volume
+            self.input_values.pop(-1)
+
+        self._remove_output_value()
+
+        for lst in self.managed_sequences:
+            if isinstance(lst, Indicator):
+                lst.remove_input_value()
+            else:
+                if len(lst) > 0:
+                    lst.pop(-1)
+
+        self._remove_input_value_custom()
+
+        for listener in self.output_listeners:
+            listener.remove_input_value()

--- a/talipp/indicators/__init__.py
+++ b/talipp/indicators/__init__.py
@@ -45,6 +45,7 @@ from .TRIX import TRIX as TRIX
 from .TSI import TSI as TSI
 from .UO import UO as UO
 from .VTX import VTX as VTX
+from .VWAP import VWAP as VWAP
 from .VWMA import VWMA as VWMA
 from .WMA import WMA as WMA
 
@@ -96,6 +97,7 @@ __all__ = (
     "TSI",
     "UO",
     "VTX",
+    "VWAP",
     "VWMA",
     "WMA",
 )

--- a/tests/TalippTest.py
+++ b/tests/TalippTest.py
@@ -67,3 +67,6 @@ class TalippTest(unittest.TestCase):
         indicator.purge_oldest(purge_size)
         self.assertSequenceEqual(indicator_copy[purge_size:], indicator)
         self.assertSequenceEqual([], indicator)
+
+    def assertIndicatorReset(self, indicator: Indicator):
+        indicator.reset()

--- a/tests/test_VWAP.py
+++ b/tests/test_VWAP.py
@@ -27,6 +27,16 @@ class Test(TalippTest):
     def test_purge_oldest(self):
         self.assertIndicatorPurgeOldest(VWAP(self.input_values))
 
+    def test_reset(self):
+        for _ in range(3):
+            ind = VWAP(self.input_values)
+            self.assertIndicatorReset(VWAP(self.input_values))
+            ind = VWAP(self.input_values)
+
+        self.assertAlmostEqual(ind[-3], 9.125770, places=5)
+        self.assertAlmostEqual(ind[-2], 9.136613, places=5)
+        self.assertAlmostEqual(ind[-1], 9.149069, places=5)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_VWAP.py
+++ b/tests/test_VWAP.py
@@ -14,6 +14,9 @@ class Test(TalippTest):
 
         print(ind)
 
+        self.assertAlmostEqual(ind[0], 10.47333, places = 5)
+        self.assertAlmostEqual(ind[1], 10.21883, places = 5)
+        self.assertAlmostEqual(ind[2], 10.20899, places = 5)
         self.assertAlmostEqual(ind[-3], 9.125770, places = 5)
         self.assertAlmostEqual(ind[-2], 9.136613, places = 5)
         self.assertAlmostEqual(ind[-1], 9.149069, places = 5)
@@ -26,16 +29,6 @@ class Test(TalippTest):
 
     def test_purge_oldest(self):
         self.assertIndicatorPurgeOldest(VWAP(self.input_values))
-
-    def test_reset(self):
-        for _ in range(3):
-            ind = VWAP(self.input_values)
-            self.assertIndicatorReset(VWAP(self.input_values))
-            ind = VWAP(self.input_values)
-
-        self.assertAlmostEqual(ind[-3], 9.125770, places=5)
-        self.assertAlmostEqual(ind[-2], 9.136613, places=5)
-        self.assertAlmostEqual(ind[-1], 9.149069, places=5)
 
 
 if __name__ == '__main__':

--- a/tests/test_VWAP.py
+++ b/tests/test_VWAP.py
@@ -1,0 +1,32 @@
+import unittest
+
+from talipp.indicators import VWAP
+
+from TalippTest import TalippTest
+
+
+class Test(TalippTest):
+    def setUp(self) -> None:
+        self.input_values = list(TalippTest.OHLCV_TMPL)
+
+    def test_init(self):
+        ind = VWAP(self.input_values)
+
+        print(ind)
+
+        self.assertAlmostEqual(ind[-3], 9.125770, places = 5)
+        self.assertAlmostEqual(ind[-2], 9.136613, places = 5)
+        self.assertAlmostEqual(ind[-1], 9.149069, places = 5)
+
+    def test_update(self):
+        self.assertIndicatorUpdate(VWAP(self.input_values))
+
+    def test_delete(self):
+        self.assertIndicatorDelete(VWAP(self.input_values))
+
+    def test_purge_oldest(self):
+        self.assertIndicatorPurgeOldest(VWAP(self.input_values))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!---
Please remove/delete previous PRs.
-->

This PR is for `VWAP` indicator with tests.

Scope of improvement: add `datatime` to `ohlcv` data (or as a separate variable) to reset season for VWAP.